### PR TITLE
Adding Stretchable Alignment Icons

### DIFF
--- a/icons/align-horizontal-stretch.json
+++ b/icons/align-horizontal-stretch.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../icon.schema.json",
+    "contributors": [
+      "MarwanFr"
+    ],
+    "tags": [
+        "items",
+        "flex",
+        "justify",
+        "align",
+        "stretch"
+    ],
+    "categories": [
+      "layout"
+    ]
+  }

--- a/icons/align-horizontal-stretch.svg
+++ b/icons/align-horizontal-stretch.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M6 12H18" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 9L6 12L9 15" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 9L18 12L15 15" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 22V2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 22V2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icons/align-vertical-stretch.json
+++ b/icons/align-vertical-stretch.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../icon.schema.json",
+    "contributors": [
+      "MarwanFr"
+    ],
+    "tags": [
+        "items",
+        "flex",
+        "justify",
+        "align",
+        "stretch"
+    ],
+    "categories": [
+      "layout"
+    ]
+  }

--- a/icons/align-vertical-stretch.svg
+++ b/icons/align-vertical-stretch.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M12 18L12 6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 15L12 18L15 15" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 9L12 6L15 9" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 22L2 22" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 2L2 2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Adding Stretchable Alignment Icons (Vertical and Horizontal)

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
* **Align Horizontal Stretch:** This icon could be used to represent horizontal alignment with stretching. For example, it could be used to indicate that an element should stretch horizontally to fill its container.
* **Align Vertical Stretch:** This icon could be used to represent vertical alignment with stretching. For example, it could be used to indicate that an element should stretch vertically to fill its container.

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [move-horizontal](https://lucide.dev/icons/move-horizontal)
- [align-horizontal-space-around](https://lucide.dev/icons/align-horizontal-space-around)

- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
